### PR TITLE
feat: Implement navigation with Navigation 3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    kotlin("plugin.serialization") version "2.2.0"
+    alias(libs.plugins.jetbrains.kotlin.serialization)
 }
 
 android {
@@ -73,6 +73,12 @@ dependencies {
 
     // Integration with ViewModels
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.2")
+
+    // Navigation 3
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+    implementation(libs.kotlinx.serialization.core)
 
     // Unit Testing Dependencies
     testImplementation(libs.junit)

--- a/app/src/main/java/com/android/rickandmortymvvm/MainActivity.kt
+++ b/app/src/main/java/com/android/rickandmortymvvm/MainActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -14,11 +13,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.rickandmortymvvm.ui.theme.RickandMortyMVVMTheme
-import com.android.rickandmortymvvm.view.MainScreen
+import com.android.rickandmortymvvm.view.AppNavigation
 import com.android.rickandmortymvvm.viewmodel.AppViewModel
 
 class MainActivity : ComponentActivity() {
-    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -27,10 +25,10 @@ class MainActivity : ComponentActivity() {
 
             RickandMortyMVVMTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    MainScreen(
-                        viewModel = viewModel,
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                        AppNavigation(
+                            viewModel = viewModel,
+                            modifier = Modifier.padding(innerPadding)
+                        )
                 }
             }
         }

--- a/app/src/main/java/com/android/rickandmortymvvm/view/AppUIScreen.kt
+++ b/app/src/main/java/com/android/rickandmortymvvm/view/AppUIScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,12 +26,14 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -42,12 +45,27 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.android.rickandmortymvvm.viewmodel.AppViewModel
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MainScreen(viewModel: AppViewModel, modifier: Modifier = Modifier) {
-    val state by viewModel.uiState.collectAsState()
+fun AppUIScreen(
+    appViewModel: AppViewModel,
+    onNavigateToDetail: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
 
-    Box(modifier = modifier.fillMaxSize()) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Rick and Morty Characters") })
+        },
+//        modifier = modifier.fillMaxSize()
+    ) { paddingValues ->
+        val state by appViewModel.uiState.collectAsState()
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
         when {
             state.isLoading -> {
                 // Centered loading indicator with expressive animation
@@ -122,7 +140,10 @@ fun MainScreen(viewModel: AppViewModel, modifier: Modifier = Modifier) {
                             ),
                             exit = fadeOut() + scaleOut()
                         ) {
-                            CharacterCard(character = character)
+                            CharacterCard(
+                                character = character,
+                                onNavigateToDetail = { onNavigateToDetail(character.id) }
+                            )
                         }
                     }
                 }
@@ -150,11 +171,15 @@ fun MainScreen(viewModel: AppViewModel, modifier: Modifier = Modifier) {
             }
         }
     }
+    }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun CharacterCard(character: com.android.rickandmortymvvm.data.model.Character) {
+private fun CharacterCard(
+    character: com.android.rickandmortymvvm.data.model.Character,
+    onNavigateToDetail: () -> Unit
+) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -163,7 +188,8 @@ private fun CharacterCard(character: com.android.rickandmortymvvm.data.model.Cha
                     dampingRatio = Spring.DampingRatioMediumBouncy,
                     stiffness = Spring.StiffnessLow
                 )
-            ),
+            )
+            .clickable { onNavigateToDetail() },
         shape = MaterialTheme.shapes.extraLarge, // Expressive shape
         elevation = CardDefaults.elevatedCardElevation(
             defaultElevation = 6.dp,

--- a/app/src/main/java/com/android/rickandmortymvvm/view/CharacterDetailsScreen.kt
+++ b/app/src/main/java/com/android/rickandmortymvvm/view/CharacterDetailsScreen.kt
@@ -1,0 +1,60 @@
+package com.android.rickandmortymvvm.view
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.android.rickandmortymvvm.viewmodel.AppViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CharacterDetailsScreen(
+    appViewModel: AppViewModel,
+    characterId: Int,
+    onBack: () -> Unit,
+    modifier: Modifier
+) {
+    val state by appViewModel.uiState.collectAsState()
+    val character = state.apps.find { it.id == characterId }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Details") })
+        },
+//        modifier = modifier.fillMaxSize()
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Button(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            if (character != null) {
+                Text(text = character.name)
+
+                AsyncImage(
+                    model = character.image,
+                    contentDescription = character.name,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                Text(text = "Character not found")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/rickandmortymvvm/view/NavKeys.kt
+++ b/app/src/main/java/com/android/rickandmortymvvm/view/NavKeys.kt
@@ -1,0 +1,10 @@
+package com.android.rickandmortymvvm.view
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+object HomeScreen : NavKey
+
+@Serializable
+data class DetailScreen(val characterId: Int) : NavKey

--- a/app/src/main/java/com/android/rickandmortymvvm/view/Navigation.kt
+++ b/app/src/main/java/com/android/rickandmortymvvm/view/Navigation.kt
@@ -1,0 +1,41 @@
+package com.android.rickandmortymvvm.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.android.rickandmortymvvm.viewmodel.AppViewModel
+
+@Composable
+fun AppNavigation(
+    viewModel: AppViewModel,
+    modifier: Modifier = Modifier
+) {
+
+    val backStack = rememberNavBackStack(HomeScreen)
+
+    NavDisplay(
+        backStack = backStack,
+        onBack = { backStack.removeLastOrNull() },
+        entryProvider = entryProvider {
+            entry<HomeScreen> {
+                AppUIScreen(
+                    appViewModel = viewModel,
+                    onNavigateToDetail = { characterId ->
+                        backStack.add(DetailScreen(characterId))
+                    },
+                    modifier = modifier
+                )
+            }
+            entry<DetailScreen> { detailScreen ->
+                CharacterDetailsScreen(
+                    appViewModel = viewModel,
+                    characterId = detailScreen.characterId,
+                    onBack = { backStack.removeLastOrNull() },
+                    modifier = modifier
+                )
+            }
+        }
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,10 @@ lifecycleRuntimeKtx = "2.9.4"
 activityCompose = "1.11.0"
 composeBom = "2025.10.01"
 material3 = "1.5.0-alpha07"
+nav3Core = "1.0.0"
+lifecycleViewmodelNav3 = "2.10.0"
+kotlinxSerializationCore = "1.8.1"
+
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,9 +29,14 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-
+jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
This commit introduces navigation to the app using the Navigation 3 library, allowing users to move from the main character list to a new detail screen.

### Key Changes:

-   **Navigation Implementation:**
    -   **`Navigation.kt`**: A new composable, `AppNavigation`, is created to manage the navigation flow. It uses `rememberNavBackStack` and `NavDisplay` to handle screen transitions.
    -   **`NavKeys.kt`**: Defines serializable navigation destinations (`HomeScreen` and `DetailScreen`) for type-safe navigation arguments.
    -   **`MainActivity.kt`**: The main activity now uses `AppNavigation` as its content, replacing the direct call to `MainScreen`.

-   **New Screens & UI Updates:**
    -   **`CharacterDetailsScreen.kt`**: A new screen to display details for a selected character. It shows the character's name and image.
    -   **`AppUIScreen.kt`**:
        -   The main list screen is now wrapped in a `Scaffold` with a `TopAppBar`.
        -   Character cards are now clickable, triggering navigation to the `CharacterDetailsScreen` with the character's ID.
        -   The function signature was updated to accept a navigation callback (`onNavigateToDetail`).

-   **Dependencies (`gradle/libs.versions.toml` & `app/build.gradle.kts`):**
    -   Added dependencies for Navigation 3:
        -   `navigation3-ui`
        -   `navigation3-runtime`
        -   `lifecycle-viewmodel-navigation3`
    -   Added `kotlinx-serialization-core` for serializing navigation arguments.
    -   Applied the `kotlinx.serialization` plugin via the version catalog.

-   **Code Cleanup:**
    -   Removed the no-longer-needed `@ExperimentalMaterial3ExpressiveApi` annotation from `MainActivity.kt`.